### PR TITLE
Fix F1 filter by contractId 

### DIFF
--- a/infoenergia_api/contrib/f1.py
+++ b/infoenergia_api/contrib/f1.py
@@ -64,12 +64,10 @@ def get_invoices(request, contractId=None):
         'lectures_potencia_ids',
         'lectures_energia_ids'
     ]
-
     if contractId:
-        filters.append(('polissa_id', '=', contractId))
-        return factura_obj.read(
-            factura_obj.search(filters, fields)
-        ) or []
+        filters.append(
+            ('polissa_id.name', '=', contractId)
+        )
 
     if request.args:
         filters = get_request_filters(

--- a/tests/test_f1.py
+++ b/tests/test_f1.py
@@ -20,7 +20,7 @@ class TestF1Base(BaseTestCase):
         )
         token = self.get_auth_token(user.username, "123412345")
 
-        _, response = self.client.get(
+        request, response = self.client.get(
             '/f1/' + self.json4test['f1_contract_id']['contractId'],
             headers={
                 'Authorization': 'Bearer {}'.format(token)
@@ -53,7 +53,7 @@ class TestF1Base(BaseTestCase):
             'tariff': '3.1A',
         }
 
-        _, response = self.client.get(
+        request, response = self.client.get(
             '/f1',
             params=params,
             headers={
@@ -68,4 +68,5 @@ class TestF1Base(BaseTestCase):
             self.json4test['f1_contracts']['contract_data']
 
         )
+        async_get_invoices_mock.assert_called_with(request)
         self.delete_user(user)


### PR DESCRIPTION
Fix F1 filter by contractId in get_invoices
Add a new endpoint filter, now we can filter by date