### PR TITLE
juridicType: add cnae filter

### DIFF
--- a/infoenergia_api/contrib/contracts.py
+++ b/infoenergia_api/contrib/contracts.py
@@ -409,7 +409,6 @@ class Contract(object):
         else:
             return True
 
-
     @property
     def juridicType(self):
         """
@@ -418,10 +417,10 @@ class Contract(object):
         or
         physicalPerson
         """
-        if self.persona_fisica == 'CI':
-            return str.join('-', ('juridicPerson', self.titular_nif[:3]))
-        else:
+        if self.persona_fisica != 'CI' and self.cnae[0] == 986:
             return 'physicalPerson'
+        else:
+            return str.join('-', ('juridicPerson', self.titular_nif[:3]))
 
     @property
     def contracts(self):

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -76,6 +76,7 @@ class TestContracts(BaseTestCase):
 
     contract_id = 4
     contract_id_3X = 158697
+    contract_id_noCIF = 82433
 
     def test__create_invoice(self):
         contract = Contract(self.contract_id)
@@ -273,4 +274,12 @@ class TestContracts(BaseTestCase):
         self.assertEqual(
             juridic_person,
             'juridicPerson-ESH'
+        )
+
+    def test__get_juridicType_juridic_personNoCIF(self):
+        contract = Contract(self.contract_id_noCIF)
+        juridic_person = contract.juridicType
+        self.assertEqual(
+            juridic_person,
+            'juridicPerson-ES7'
         )


### PR DESCRIPTION
Add cnae filter to juridic type property. This allows to identify juridic persons that hire with a DNI.