### PR TITLE
Fix cups filter for contractId

### DIFF
--- a/infoenergia_api/contrib/f5d.py
+++ b/infoenergia_api/contrib/f5d.py
@@ -101,7 +101,7 @@ def get_f5d(request, contractId=None):
 
     if contractId:
         cups = get_cups(request, contractId)
-        filters.update({"name": { "$in": cups }})
+        filters.update({"name": { '$regex': '^{}'.format(cups[:20])}})
 
     if request.args:
         filters = get_cch_filters(request, filters)


### PR DESCRIPTION
Fix cups filter: 
Filter CUPS by regex, since some of the CUPS that we get in F5D only have the first 20 digits informed, while in our ERP most of the CUPS have 22. 

