### PR TITLE
Refactor f1 curves from ERP

### DIFF
--- a/infoenergia_api/__init__.py
+++ b/infoenergia_api/__init__.py
@@ -28,6 +28,7 @@ from .api.reports import bp_reports
 from .api.tariff import bp_tariff
 from .api.utils import get_db_instance
 from .contrib.mixins import ResponseMixin
+from .contrib.erp import get_erp_instance
 
 
 def attach_signals(app: Sanic):
@@ -87,12 +88,10 @@ def attach_bluprints_and_routes(app: Sanic):
 
 def attach_context(app: Sanic):
     app.ctx.thread_pool = futures.ThreadPoolExecutor(app.config.MAX_THREADS)
-    app.ctx.erp_client = Client(
-        transport=PoolTransport(secure=app.config.TRANSPORT_POOL_CONF["secure"]),
-        **app.config.ERP_CONF,
-    )
 
+    app.ctx.erp_client = get_erp_instance()
     db = get_db_instance()
+
     try:
         db.bind(
             provider="sqlite",

--- a/infoenergia_api/contrib/cch.py
+++ b/infoenergia_api/contrib/cch.py
@@ -1,22 +1,24 @@
 import asyncio
 from bson.objectid import ObjectId
-from datetime import timedelta
+from datetime import timedelta, datetime
 import pytz
 
-from ..utils import get_cch_filters, make_uuid, get_contract_id
+from sanic import Sanic
+
+from ..utils import get_cch_query, make_uuid, get_contract_id, get_cch_erp_query
 from ..tasks import get_cups
+from .erp import get_erp_instance
 
 
 class BaseCch(object):
 
     iso_format = "%Y-%m-%d %H:%M:%S"
+    _erp = get_erp_instance()
 
     @classmethod
     async def create(cls, cch_id, collection):
-        from infoenergia_api.app import app
-
+        app = Sanic.get_app()
         self = cls()
-        self._erp = app.ctx.erp_client
         self._executor = app.ctx.thread_pool
         self._mongo = app.ctx.mongo_client.somenergia
         self._collection = collection
@@ -109,10 +111,26 @@ class TgCchVal(BaseCch):
 
 
 class TgCchF1(BaseCch):
+
+    erp_model = "tg.f1"
+
     @classmethod
     async def create(cls, cch_id):
-        cch_fact_curve = await super().create(cch_id, "tg_f1")
-        return cch_fact_curve
+        self = cls()
+        self._loop = asyncio.get_running_loop()
+        self.TgF1 = self._erp.model(self.erp_model)
+        self.raw_curve = await self._loop.run_in_executor(None, self.TgF1.read, cch_id)
+
+        for name, value in self.raw_curve.items():
+            setattr(self, name, value)
+        return self
+
+    @property
+    def date_cch(self):
+        _utc_timestamp = datetime.strptime(
+            self.utc_timestamp, "%Y-%m-%d %H:%M:%S"
+        ).replace(tzinfo=pytz.UTC)
+        return _utc_timestamp.strftime("%Y-%m-%d %H:%M:%S%z")
 
     @property
     def measurements(self):
@@ -129,9 +147,9 @@ class TgCchF1(BaseCch):
             "r4": self.r4,
             "source": self.source,
             "validated": self.validated,
-            "date": self.dateCch,
-            "dateDownload": (self.create_at).strftime(self.iso_format),
-            "dateUpdate": (self.update_at).strftime(self.iso_format),
+            "date": self.date_cch,
+            "dateDownload": self.create_at,
+            "dateUpdate": self.update_at,
             "reserve1": self.reserve1,
             "reserve2": self.reserve2,
             "measureType": self.measure_type,
@@ -178,21 +196,36 @@ class TgCchP1(BaseCch):
 
 
 async def async_get_cch(request, contract_id=None):
-    filters = {}
     loop = asyncio.get_running_loop()
-
-    collection = request.args.get("type")
-    if collection in ("P1", "P2"):
-        collection = "tg_p1"
-    cch_collection = request.app.ctx.mongo_client.somenergia[collection]
+    filters = request.args
+    cups = None
 
     if contract_id:
         cups = await loop.run_in_executor(None, get_cups, request, contract_id)
         if not cups:
             return []
-        filters.update({"name": {"$regex": "^{}".format(cups[0][:20])}})
 
-    if request.args:
-        filters = await get_cch_filters(request, filters)
+    collection = filters.get("type")
+    if collection != "tg_f1":
+        return await get_from_mongo(
+            request.app.ctx.mongo_client, collection, filters, cups
+        )
 
-    return [cch["_id"] async for cch in cch_collection.find(filters) if cch.get("_id")]
+    return await get_from_erp(get_erp_instance(), collection, filters, cups)
+
+
+async def get_from_mongo(mongo_client, collection, filters, cups):
+    query = await get_cch_query(filters, cups)
+    if collection in ("P1", "P2"):
+        collection = "tg_p1"
+    cch_collection = mongo_client.somenergia[collection]
+
+    return [cch["_id"] async for cch in cch_collection.find(query) if cch.get("_id")]
+
+
+async def get_from_erp(erp, collection, filters, cups):
+    loop = asyncio.get_running_loop()
+    collection_map = {"tg_f1": "tg.f1"}
+    model = erp.model(collection_map.get(collection))
+    query = await get_cch_erp_query(filters, cups)
+    return await loop.run_in_executor(None, model.search, query)

--- a/infoenergia_api/contrib/contracts.py
+++ b/infoenergia_api/contrib/contracts.py
@@ -36,6 +36,7 @@ class Contract(object):
         "persona_fisica",
         "titular_nif",
         "llista_preu",
+        "tipo_medida",
     ]
 
     def __init__(self, contract_id):
@@ -495,7 +496,10 @@ class Contract(object):
                 "profile": self.eprofile,
                 "customisedServiceParameters": self.service,
             },
-            "devices": self.devices,
+            "devices": {
+                self.tipo_medida,
+                self.devices,
+            },
             "report": self.report,
             "version": self.version,
             "experimentalGroupUserTest": False,

--- a/infoenergia_api/contrib/erp/__init__.py
+++ b/infoenergia_api/contrib/erp/__init__.py
@@ -1,0 +1,1 @@
+from .manager import get_erp_instance

--- a/infoenergia_api/contrib/erp/manager.py
+++ b/infoenergia_api/contrib/erp/manager.py
@@ -1,0 +1,26 @@
+from erppeek import Client
+from pool_transport import PoolTransport
+
+from config import config
+
+
+class ERPManager:
+    """
+    Tiny class to manage erp connection to be accesible for any part of the code
+    """
+
+    _erp_con = None
+
+    @classmethod
+    def _erp_instance(cls) -> Client:
+        if cls._erp_con is None:
+            cls._erp_con = Client(
+                transport=PoolTransport(secure=config.TRANSPORT_POOL_CONF["secure"]),
+                **config.ERP_CONF,
+            )
+
+        return cls._erp_con
+
+
+def get_erp_instance() -> Client:
+    return ERPManager._erp_instance()

--- a/infoenergia_api/tasks.py
+++ b/infoenergia_api/tasks.py
@@ -1,8 +1,11 @@
 from datetime import datetime
 
+from sanic.log import logger
+
 from infoenergia_api.contrib.climatic_zones import ine_to_zc
 from infoenergia_api.contrib.postal_codes import ine_to_dp
 
+from .contrib.erp import get_erp_instance
 from .utils import (
     make_timestamp,
     make_uuid,
@@ -367,21 +370,18 @@ def get_experimentalgroup(erp_client, cups_id):
 
 
 def get_cups(request, contractId=None):
-    contract_obj = request.app.ctx.erp_client.model("giscedata.polissa")
+    erp = get_erp_instance()
+    contract_obj = erp.model("giscedata.polissa")
     filters = [
         ("active", "=", True),
         ("state", "=", "activa"),
         ("emp_allow_send_data", "=", True),
         ("name", "=", contractId),
     ]
-
-    filters = get_contract_user_filters(
-        request.app.ctx.erp_client, request.ctx.user, filters
-    )
-
+    filters = get_contract_user_filters(erp, request.ctx.user, filters)
     if request.args:
         filters = get_request_filters(
-            request.app.ctx.erp_client,
+            erp,
             request,
             filters,
         )

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -59,7 +59,7 @@ def user():
             email="someone@foo.bar",
             id_partner=1,
             is_superuser=True,
-            category="partner",
+            category="admin",
         )
         commit()
     user._clear_psw = "password"
@@ -149,7 +149,7 @@ def f1_id():
     """
     Returns a random f1 curve id
     """
-    return "5e1d8d9612cd738e89bb3cfb"
+    return 721
 
 
 @pytest.fixture

--- a/tests/test_cch.py
+++ b/tests/test_cch.py
@@ -92,6 +92,32 @@ class TestCchRequest:
         assert response.status == 200
         assert response.json == {"count": 0, "total_results": 0, "data": []}
 
+    async def test__get_f1_by_id(self, app, auth_token, scenarios, mocked_next_cursor):
+        params = {
+            "from_": "2018-11-16",
+            "to_": "2023-01-20",
+            "limit": 10,
+            "type": "tg_f1",
+        }
+        _, response = await app.asgi_client.get(
+            "/cch/{}".format(scenarios["tg_f1"]["contractId"]),
+            headers={"Authorization": "Bearer {}".format(auth_token)},
+            params=params,
+        )
+        assert response.status == 200
+        assert response.json["count"] == 10
+        assert response.json["total_results"] == 13201
+        assert (
+            response.json["cursor"]
+            == "N2MxNjhhYmItZjc5Zi01MjM3LTlhMWYtZDRjNDQzY2ZhY2FkOk1RPT0="
+        )
+        assert response.json[
+            "next_page"
+        ] == "http://{}/cch/{}?type=tg_f1&cursor=N2MxNjhhYmItZjc5Zi01MjM3LTlhMWYtZDRjNDQzY2ZhY2FkOk1RPT0=&limit=10".format(
+            response.url.netloc.decode(), scenarios["tg_f1"]["contractId"]
+        )
+        assert len(response.json["data"]) == 10
+
     async def test__get_p1__for_contract_id(
         self, app, auth_token, scenarios, mocked_next_cursor
     ):
@@ -160,29 +186,29 @@ class TestCchModels:
             "validated": True,
         }
 
-    async def test__create_f1(self, f1_id, app):
+    async def test__create_f1(self, f1_id, event_loop):
         f1 = await TgCchF1.create(f1_id)
         assert isinstance(f1, TgCchF1)
 
-    async def test__get_f1_measurements(self, f1_id, app):
+    async def test__get_f1_measurements(self, f1_id, event_loop):
         f1 = await TgCchF1.create(f1_id)
         measurements = f1.measurements
         assert measurements == {
-            "ai": 14.0,
+            "season": 1,
+            "ai": 5.0,
             "ao": 0.0,
-            "date": "2017-12-01 22:00:00+0000",
-            "dateUpdate": "2020-01-14 10:44:54",
-            "season": 0,
-            "validated": False,
-            "r1": 1.0,
+            "r1": 3.0,
             "r2": 0.0,
             "r3": 0.0,
-            "r4": 2.0,
-            "reserve1": 0,
-            "reserve2": 0,
+            "r4": 0.0,
             "source": 1,
+            "validated": 0,
+            "date": "2022-05-31 22:00:00+0000",
+            "dateDownload": "2022-09-19 13:44:56",
+            "dateUpdate": "2022-09-19 13:44:56",
+            "reserve1": 0.0,
+            "reserve2": 0.0,
             "measureType": 11,
-            "dateDownload": "2020-01-14 10:44:54",
         }
 
     async def test__get_P1_measurements(self, p1_id, app):


### PR DESCRIPTION
In this pull request, we changed the way of we obtain he cch_f1 curves. In order to adapt us to the new cch storage system

Also, as a last minute requirement request, `tipo_medida` attribute has been added to `Contract `model, so `devices` attribute now looks like
```python
{
...
    "devices": {
        self.tipo_medida,
        self.devices,
    },
...
}