### PR TITLE
Fix missing tests and docs autocons gennetabeta

### DIFF
--- a/docs/infoenergia-api.yaml
+++ b/docs/infoenergia-api.yaml
@@ -474,6 +474,8 @@ components:
             - tg_cchfact
             - tg_cchval
             - tg_f1
+            - tg_gennetabeta
+            - tg_autocons
             - P1
             - P2
     cchDownloadedFromParam:


### PR DESCRIPTION
- snapshot test for every curve type. Those test are migrated from the kludgy back2back test we did to refactor the curve retrievers. Require the somenergia-back2backdata repository from the private gitlab.
- add the enums for the new curve to the openapi documentation (the new values were added in the description but not in the accepted values)