### PR TITLE
Fix tariff filters

### DIFF
--- a/infoenergia_api/api/contracts/views.py
+++ b/infoenergia_api/api/contracts/views.py
@@ -6,7 +6,7 @@ from infoenergia_api.contrib import (
     ResponseMixin,
 )
 from infoenergia_api.contrib.contracts import async_get_contracts
-from infoenergia_api.contrib.tariff import async_get_tariff_prices
+from infoenergia_api.contrib.tariff import async_get_tariff_prices, get_tariff_filters
 
 from sanic import Blueprint
 from sanic.log import logger
@@ -96,11 +96,13 @@ class ContractsIdTariffView(ResponseMixin, PaginationLinksMixin, HTTPMethodView)
             return self.error_response(e)
 
         else:
-            tariff_price_filters, links, total_results = await self.paginate_results(
-                request, function=async_get_tariff_prices, contract_id=contracts_ids
+            tariff_price_filters = get_tariff_filters(request, contract_id=contracts_ids)
+
+            tariff_price_ids, links, total_results = await self.paginate_results(
+                request, function=async_get_tariff_prices
             )
             tariff_prices = [
-                await TariffPrice.create(filters=tariff_price_filters)
+                await TariffPrice.create(tariff_price_filters, tariff_price_ids)
             ]
 
             base_response = {"total_results": total_results, **links}

--- a/infoenergia_api/contrib/contracts.py
+++ b/infoenergia_api/contrib/contracts.py
@@ -86,7 +86,7 @@ class Contract(object):
 
             self._current_tariff = {
                 "tariffId": modcon["tarifa"][1],
-                "tariffPriceId": modcon["llista_preu"][0],
+                "tariffPriceId": modcon["tarifa"][0],
                 "dateStart": make_timestamp(modcon["data_inici"]),
                 "dateEnd": make_timestamp(modcon["data_final"]),
             }
@@ -113,7 +113,7 @@ class Contract(object):
         return [
             {
                 "tariffId": modcon["tarifa"][1],
-                "tariffPriceId": modcon["llista_preu"][0],
+                "tariffPriceId": modcon["tarifa"][0],
                 "dateStart": make_timestamp(modcon["data_inici"]),
                 "dateEnd": make_timestamp(modcon["data_final"]),
             }

--- a/infoenergia_api/contrib/mixins.py
+++ b/infoenergia_api/contrib/mixins.py
@@ -24,7 +24,8 @@ class ResponseMixin(object):
                 todo, timeout=request.app.config.TASKS_TIMEOUT
             )
             for task in done:
-                serialized_instances.append(task.result())
+                if task.result() != {}:
+                    serialized_instances.append(task.result())
 
         response = {
             "count": len(serialized_instances),

--- a/infoenergia_api/contrib/tariff.py
+++ b/infoenergia_api/contrib/tariff.py
@@ -79,16 +79,20 @@ class TariffPrice(object):
         current = self.tariff_format if self.price_data else {}
 
         for tariff_price in tariff_prices['history']:
-            self.price_data = tariff_price
-            history.append(self.tariff_format)
+            if tariff_price:
+                self.price_data = tariff_price
+                history.append(self.tariff_format)
         return current, history
 
     @property
     def tariff(self):
         tariff_prices = self.get_erp_tariff_prices
         if "error" in tariff_prices.keys():
-           return {"error": tariff_prices.get("error", False)}
-        else:
+            logger.debug(
+               "error %d for tariff_id %d",
+               tariff_prices.get("error", False), self.tariff_id
+            )
+        if tariff_prices and not "error" in tariff_prices.keys():
             if self.contract_id:
                 contract_tariff_prices = {"history": []}
                 for tariff_id, tariff_price in tariff_prices.items():

--- a/infoenergia_api/contrib/tariff.py
+++ b/infoenergia_api/contrib/tariff.py
@@ -88,11 +88,8 @@ class TariffPrice(object):
     def tariff(self):
         tariff_prices = self.get_erp_tariff_prices
         if "error" in tariff_prices.keys():
-            logger.debug(
-               "error %d for tariff_id %d",
-               tariff_prices.get("error", False), self.tariff_id
-            )
-        if tariff_prices and not "error" in tariff_prices.keys():
+            return {"error": tariff_prices.get("error", False), "tariffPriceId": self.tariff_id}
+        if tariff_prices:
             if self.contract_id:
                 contract_tariff_prices = {"history": []}
                 for tariff_id, tariff_price in tariff_prices.items():
@@ -119,7 +116,8 @@ class TariffPrice(object):
                 }
 
     def __iter__(self):
-        yield from self.tariff.items()
+        if not 'error' in self.tariff.keys():
+            yield from self.tariff.items()
 
 
 def get_tariff_filters(request, contract_id=None):

--- a/infoenergia_api/contrib/tariff.py
+++ b/infoenergia_api/contrib/tariff.py
@@ -57,13 +57,13 @@ class TariffPrice(object):
         return {
             "dateStart": self.price_data["start_date"],
             "dateEnd": self.price_data["end_date"],
-            "activeEnergy": self.price_data["energia"],
-            "power": self.price_data["potencia"],
-            "gkwh": self.price_data["generation_kWh"],
-            "autoconsumo": self.price_data["energia_autoconsumida"],
+            "activeEnergy": dict(sorted(self.price_data["energia"].items())),
+            "power":  dict(sorted(self.price_data["potencia"].items())),
+            "gkwh": dict(sorted(self.price_data["generation_kWh"].items())),
+            "autoconsumo": dict(sorted(self.price_data["energia_autoconsumida"].items())),
             "meter": self.price_data["comptador"],
             "bonoSocial": self.price_data["bo_social"],
-            "reactiveEnergy": self.price_data["reactiva"],
+            "reactiveEnergy": dict(sorted(self.price_data["reactiva"].items())),
             "taxes": {
                 "name": self.price_data['fiscal_position']['name'],
                 "dateStart": self.price_data['fiscal_position']['date_from'],

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -262,7 +262,7 @@ class TestContracts(BaseTestCase):
             tariff,
             {
                 "tariffId": "2.0TD",
-                "tariffPriceId": 101,
+                "tariffPriceId": 43,
                 "dateStart": "2022-01-11T00:00:00+01:00",
                 "dateEnd": "2024-03-09T00:00:00+01:00"
             }
@@ -276,19 +276,19 @@ class TestContracts(BaseTestCase):
             [
                 {
                     "tariffId": "2.0A",
-                    "tariffPriceId": 4,
+                    "tariffPriceId": 1,
                     "dateStart": "2011-12-31T00:00:00+01:00",
                     "dateEnd": "2019-06-05T00:00:00+02:00"
                 },
                 {
                     "tariffId": "2.0DHS",
-                    "tariffPriceId": 18,
+                    "tariffPriceId": 4,
                     "dateStart": "2019-06-06T00:00:00+02:00",
                     "dateEnd": "2021-05-31T00:00:00+02:00"
                 },
                 {
                 "tariffId": "2.0TD",
-                "tariffPriceId": 101,
+                "tariffPriceId": 43,
                 "dateStart": "2021-06-01T00:00:00+02:00",
                 "dateEnd": "2024-04-17T00:00:00+02:00"
                 }

--- a/tests/test_tariff.py
+++ b/tests/test_tariff.py
@@ -116,39 +116,6 @@ class TestBaseTariff(BaseTestCase):
         self.delete_user(user)
 
     @db_session
-    def test__get_tariff__3A_non_prices_today(self):
-        user = self.get_or_create_user(
-            username="someone",
-            password=self.dummy_passwd,
-            email="someone@somenergia.coop",
-            partner_id=1,
-            is_superuser=True,
-            category="partner",
-        )
-        token = self.get_auth_token(user.username, self.dummy_passwd)
-        params = {
-            "type": "3.0A",
-        }
-        _, response = self.loop.run_until_complete(
-            self.client.get(
-                "/tariff",
-                headers={"Authorization": "Bearer {}".format(token)},
-                params=params,
-                timeout=None,
-            )
-        )
-
-        self.assertEqual(response.status, 200)
-
-        self.assertDictEqual(
-            response.json, {
-                "count": 1,
-                "data": [{'error': 'Tariff pricelist not found'}],
-                'total_results': 2}
-        )
-        self.delete_user(user)
-
-    @db_session
     def test__get_tariff__3A_with_prices(self):
         user = self.get_or_create_user(
             username="someone",
@@ -258,7 +225,7 @@ class TestTariff(BaseTestCase):
         tariff = TariffPrice(self.filters, self.tariff_id_2TD)
         _prices = tariff.tariff
 
-        self.assertEqual(_prices, {'error': 'Tariff pricelist not found'})
+        self.assertEqual(_prices, None)
 
     def test__get_erp_tariff_prices__2TD_price_power(self):
         # Select old prices for tariff 2.0TD
@@ -312,8 +279,9 @@ class TestTariff(BaseTestCase):
         self.filters['to_'] = '2022-12-01'
         tariff = TariffPrice( self.filters, self.tariff_id_3TD)
         prices = tariff.tariff
+
         self.assertEqual(
-            prices['prices']['history'][0]['GKWh'],
+            prices['prices']['history'][0]['gkwh'],
             {
                 'P1': {'unit': '€/kWh', 'value': 0.144},
                 'P2': {'unit': '€/kWh', 'value': 0.132},

--- a/tests/test_tariff.py
+++ b/tests/test_tariff.py
@@ -41,7 +41,7 @@ class TestBaseTariff(BaseTestCase):
             {
                 "count": 1,
                 "data": self.json4test["price2A"]["data_TwoPrices"],
-                "total_results": 4
+                "total_results": 1
             }
         )
         self.delete_user(user)
@@ -178,7 +178,7 @@ class TestBaseTariff(BaseTestCase):
             response.json, {
                 "count": 1,
                 "data": self.json4test["price3A"]["data_prices"],
-                'total_results': 4
+                'total_results': 1
             }
         )
         self.delete_user(user)

--- a/tests/test_tariff.py
+++ b/tests/test_tariff.py
@@ -91,6 +91,7 @@ class TestBaseTariff(BaseTestCase):
         token = self.get_auth_token(user.username, self.dummy_passwd)
         params = {
             "tariffPriceId": 43,
+            "withTaxes": False,
         }
         _, response = self.loop.run_until_complete(
             self.client.get(
@@ -103,6 +104,7 @@ class TestBaseTariff(BaseTestCase):
         self.assertEqual(response.status, 200)
 
         prices = response.json['data'][0]['prices']
+        taxes = response.json['data'][0]['prices']['current']['taxes']
         tariffPriceId = response.json['data'][0]['tariffPriceId']
         self.assertTrue(
             len(prices) > 0
@@ -110,6 +112,7 @@ class TestBaseTariff(BaseTestCase):
         self.assertTrue(
             tariffPriceId == 43
         )
+        self.assertEqual(taxes, {})
         self.delete_user(user)
 
     @db_session
@@ -387,7 +390,7 @@ class TestTariff(BaseTestCase):
         self.filters['withTaxes'] = True
         self.filters['geographicalRegion'] = "canarias"
 
-        tariff = TariffPrice( self.filters, self.tariff_id_2TD)
+        tariff = TariffPrice(self.filters, self.tariff_id_2TD)
         prices = tariff.tariff
 
         self.assertEqual(prices['prices']['history'][0]['dateEnd'], '2022-12-31')

--- a/tests/test_tariff.py
+++ b/tests/test_tariff.py
@@ -173,6 +173,22 @@ class TestBaseTariff(BaseTestCase):
             tariffPriceId == 43
         )
 
+    @db_session
+    def test__get_tariff__2A_without_results(self):
+        params = {
+            "type": "2.0A"
+        }
+        _, response = self.loop.run_until_complete(
+            self.client.get(
+                "/tariff",
+                params=params,
+                timeout=None,
+            )
+        )
+
+        self.assertEqual(response.status, 200)
+        prices = response.json
+        self.assertEqual(prices['data'], [])
 
 class TestTariff(BaseTestCase):
 


### PR DESCRIPTION

- Fix "false" filters:
   - Boolean value as string   in request
- Remove unrequired data:
   - remove empty dicts from price result
   - remove error when tariff not found
- Order periods in tariff response
