### PR TITLE
FIX: missing downloaded filters

### DIFF
--- a/infoenergia_api/contrib/cch/__init__.py
+++ b/infoenergia_api/contrib/cch/__init__.py
@@ -20,8 +20,18 @@ class CurveRepository:
     def __init__(self, backend):
         self.backend = backend
 
-    async def get_curve(self, start, end, cups=None):
-        return await self.backend.get_curve(self, start, end, cups)
+    async def get_curve(
+        self,
+        start, end,
+        downloaded_from=None, downloaded_to=None,
+        cups=None
+    ):
+        return await self.backend.get_curve(
+            self,
+            start, end,
+            downloaded_from, downloaded_to,
+            cups
+        )
 
     def measurements(self, raw_data):
         return dict(
@@ -214,9 +224,18 @@ def create_repository(curve_type):
     return CurveType(Backend())
 
 
-async def get_curve(curve_type, start, end, cups=None):
+async def get_curve(
+    curve_type,
+    start, end,
+    downloaded_from=None, downloaded_to=None,
+    cups=None
+):
     repository = create_repository(curve_type)
-    return await repository.get_curve(start, end, cups=cups)
+    return await repository.get_curve(
+        start=start, end=end,
+        downloaded_from=downloaded_from, downloaded_to=downloaded_to,
+        cups=cups
+    )
 
 
 async def get_measures(curve_type, cch, contract_id, user):
@@ -256,6 +275,8 @@ async def async_get_cch(request, contract_id=None):
         curve_type,
         start=filters.get('from_', None),
         end=filters.get('to_', None),
+        downloaded_from=filters.get('downloaded_from', None),
+        downloaded_to=filters.get('downloaded_to', None),
         cups=cups,
     )
     return result

--- a/infoenergia_api/contrib/cch/mongo_curve_backend.py
+++ b/infoenergia_api/contrib/cch/mongo_curve_backend.py
@@ -56,8 +56,21 @@ class MongoCurveBackend:
             query.update(name={"$regex": "^{}".format(cups[:20])})
         return query
 
-    async def get_curve(self, curve_type, start, end, cups=None):
-        query = self.build_query(start, end, cups, **curve_type.extra_filter)
+    async def get_curve(
+        self,
+        curve_type,
+        start, end,
+        downloaded_from=None, downloaded_to=None,
+        cups=None
+    ):
+
+        query = self.build_query(
+            start=start, end=end,
+            downloaded_from=downloaded_from, downloaded_to=downloaded_to,
+            cups=cups,
+            **curve_type.extra_filter
+        )
+
         cch_collection = self.db[curve_type.model]
 
         def cch_transform(cch):

--- a/infoenergia_api/contrib/cch/timescale_curve_backend.py
+++ b/infoenergia_api/contrib/cch/timescale_curve_backend.py
@@ -55,19 +55,29 @@ class TimescaleCurveBackend:
 
         return result
 
-    async def get_curve(self, curve_type, start, end, cups=None):
-
+    async def get_curve(
+        self,
+        curve_type,
+        start, end,
+        downloaded_from=None, downloaded_to=None,
+        cups=None
+    ):
         def cch_transform(cch):
-            return dict(cch,
+            return dict(
+                cch,
                 date=cch_date_from_cch_utctimestamp(cch, curve_type.measure_delta),
                 dateDownload=iso_format(cch["create_at"]),
                 dateUpdate=iso_format(cch["update_at"]),
                 datetime=iso_format(cch["datetime"]),
                 utc_timestamp=iso_format(cch["utc_timestamp"]),
-
             )
-        query = await self.build_query(start, end, cups, **curve_type.extra_filter)
 
+        query = await self.build_query(
+            start=start, end=end,
+            downloaded_from=downloaded_from, downloaded_to=downloaded_to,
+            cups=cups,
+            **curve_type.extra_filter
+        )
         erpdb = await get_erpdb_instance()
         async with AsyncClientCursor(erpdb, row_factory=dict_row) as cursor:
             await cursor.execute(f"""

--- a/tests/test_cch.py
+++ b/tests/test_cch.py
@@ -114,6 +114,42 @@ class TestCchRequest:
         ))
         assert len(response.json["data"]) == 10
 
+    async def test__f5d_contract_id__download_filters__pagination_limit_2(
+        self,
+        cchquery,
+        scenarios,
+        yaml_snapshot
+    ):
+        contract_id = scenarios["a_valid_f5d_contract_id"]
+
+        response = await cchquery(
+            contract_id=contract_id,
+            params={
+                "type": "tg_cchfact",
+                "downloaded_from": "2023-03-24",
+                "downloaded_to": "2023-03-26",
+                "limit": 2,
+            },
+        )
+
+        cursor = response.json.get("cursor", "NO_CURSOR_RETURNED")
+        assert_response_contains(response, ns(
+            count=2,
+            total_results=624,
+            next_page="http://{}/cch/{}?type=tg_cchfact&cursor={}&limit=2".format(
+                response.url.netloc.decode(),
+                contract_id,
+                cursor
+            ),
+        ))
+        assert len(response.json["data"]) == 2
+        assert("2023-03" in response.json["data"][0]['measurements']['dateDownload'])
+        assert("2023-03" in response.json["data"][1]['measurements']['dateDownload'])
+        yaml_snapshot(ns(
+            status=response.status,
+            json=response.json,
+        ))
+
     async def test__f5d__all_contracts__pagination(self, cchquery, scenarios):
         response = await cchquery(
             params = {


### PR DESCRIPTION
## Description

This PR adds missing `downloaded_from` and `downloaded_to` filters when building curves queries.

## Executable verification notes

To check it out a new test has been added:

```bash
pipenv run pytest tests/test_cch.py -k test__f5d_contract_id__download_filters__pagination_limit_2 
```

You can use the available smoketest as well.

Don't forget to update snapshot and testdata repositories.

