### PR TITLE
Get invoices by contract performance

### DIFF
--- a/infoenergia_api/api/f1_measures/views.py
+++ b/infoenergia_api/api/f1_measures/views.py
@@ -6,7 +6,11 @@ from sanic.response import json
 from sanic.views import HTTPMethodView
 from sanic_jwt.decorators import inject_user, protected
 
-from infoenergia_api.contrib.f1 import async_get_invoices, Invoice
+from infoenergia_api.contrib.f1 import (
+    async_get_invoices,
+    async_get_invoices_by_contract_id,
+    Invoice
+)
 from infoenergia_api.contrib import PaginationLinksMixin
 from infoenergia_api.contrib.mixins import ResponseMixin
 from infoenergia_api.contrib.pagination import PageNotFoundError
@@ -29,7 +33,9 @@ class F1MeasuresContractIdView(ResponseMixin, PaginationLinksMixin, HTTPMethodVi
 
         try:
             invoices_ids, links, total_results = await self.paginate_results(
-                request, function=async_get_invoices, contract_id=contract_id
+                request,
+                function=async_get_invoices_by_contract_id,
+                contract_id=contract_id
             )
         except PageNotFoundError as e:
             return self.error_response(e)

--- a/tests/test_f1.py
+++ b/tests/test_f1.py
@@ -287,21 +287,24 @@ class TestInvoice(BaseTestCase):
         invoice = Invoice(self.invoice_id_2x)
 
         devices = invoice.devices
+
         self.assertListEqual(
             devices,
             [
                 {
-                    "dateStart": "2011-12-23T00:00:00+01:00",
-                    "dateEnd": None,
-                    "deviceId": "ab201f66-4da7-517b-be40-13b7e0de7429",
-                }
-            ],
+                    'dateStart': '2022-06-28T00:00:00+02:00',
+                    'dateEnd': None,
+                    'deviceId': '4385c40f-388c-50ff-94b8-ccb9d3607ec6'
+                 }
+            ]
         )
 
     def test__f1_power_2X(self):
-        invoice = Invoice(self.invoice_id_2x)
+        a_20td_invoice_id_without_f1_values = 202528
+        invoice = Invoice(a_20td_invoice_id_without_f1_values)
 
         f1_power = invoice.f1_power_kW
+
         self.assertListEqual(f1_power, [])
 
     def test__f1_power_3X(self):
@@ -343,20 +346,13 @@ class TestInvoice(BaseTestCase):
         )
 
     def test__get_f1_active_energy_2X(self):
-        invoice = Invoice(self.invoice_id_2x)
+        invoice = Invoice(self.json4test['invoice_20TD']['id'])
 
         f1_active_energy = invoice.f1_active_energy_kWh
+
         self.assertListEqual(
             f1_active_energy,
-            [
-                {
-                    "consum": 280,
-                    "period": "P1",
-                    "source": "Telegestió",
-                    "magnitud": "AE",
-                    "units": "kWh",
-                }
-            ],
+            self.json4test['invoice_20TD']['f1_active_energy']
         )
 
     def test__get_f1_active_energy_3X(self):
@@ -540,7 +536,9 @@ class TestInvoice(BaseTestCase):
         )
 
     def test__f1_maximeter__without_results(self):
-        invoice = Invoice(self.invoice_id_2x)
+        a_20td_invoice_id_without_maximeter_values = 283681
+        invoice = Invoice(a_20td_invoice_id_without_maximeter_values)
 
         f1_maximeter = invoice.f1_maximeter
+
         self.assertListEqual(f1_maximeter, [])


### PR DESCRIPTION
## Description
Improves performance when retrieving f1 curves data.

## Changes
*  erppeek domain JOIN strategy has been splitted to avoid low performance SQL statements

## Observations
* Low performance SQL queries were blocking postgresql server and overlapping data ingestion pipelines creating concurrent request scenarios difficult to deal with.

## Please, review
* f1 endpoint changing values for `from_` and `to_` params to retrieve empty and no empty response data, e.g.:

```
/f1/{contract}?from_=2023-04-19&to_=2023-05-26&limit=2000'
```
check response time is under 5 seconds.


* Execute f1 tests to verify they are working properly, don't forget to update your testdata local repository:
```
pipenv run pytest tests/test_f1.py
```

## Deploy notes
None

